### PR TITLE
Modifications for Ruby 1.9 and better

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -209,6 +209,12 @@ sub interrogate {
     $ref->{incpath} ||= [ $ref->{libpath} ];
     return if -f catfile($ref->{libpath}, $ref->{libruby});
 
+    my $libdirname = get_config_var($ref, "LIBDIRNAME");
+    $libdirname = 'libdir' unless defined $libdirname && length $libdirname;
+    my $libdir = get_config_var($ref, $libdirname);
+    $ref->{libpath} .= qq{ -L$libdir}
+        if defined $libdir && length $libdir;
+
     # If ruby has been compiled for libruby.so, it continues to think
     # libruby.so is living in .../lib/ruby/1.6/$arch/; but the Makefile
     # installs it into .../lib/. Correct for that here:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -178,7 +178,7 @@ sub interrogate {
     $ref->{syslibs} = get_config_var($ref, "LIBS");
     $ref->{libruby} = get_config_var($ref, "LIBRUBY");
     my $enable_shared = get_config_var($ref, "ENABLE_SHARED");
-    my $libruby_a = get_config_var($rev, "LIBRUBY_A");
+    my $libruby_a = get_config_var($ref, "LIBRUBY_A");
     if ($enable_shared && $ref->{libruby} ne $libruby_a) {
             $ref->{libruby} = get_config_var($ref, "LIBRUBYARG");
     }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -70,11 +70,10 @@ print "Using $sel->{path}\n";
 #============================================================================
 interrogate($sel);
 
-# Fix up the libpath and libruby
+# Fix up the libpath
 # substr($sel->{incpath}, 0, 0) = "-I";
 my $inc_path = join(' ', map { "-I$_" } @{$sel->{incpath}});
 substr($sel->{libpath}, 0, 0) = "-L";
-$sel->{libruby} =~ s/lib(.*)(?:\.\Q$Config{dlext}\E|\Q$Config{_a}\E).*/-l$1/;
 
 my @flags;
 push @flags, debug_flag() if defined $gdb;
@@ -178,6 +177,11 @@ sub interrogate {
     my $ref = shift;
     $ref->{syslibs} = get_config_var($ref, "LIBS");
     $ref->{libruby} = get_config_var($ref, "LIBRUBY");
+    my $enable_shared = get_config_var($ref, "ENABLE_SHARED");
+    my $libruby_a = get_config_var($rev, "LIBRUBY_A");
+    if ($enable_shared && $ref->{libruby} ne $libruby_a) {
+            $ref->{libruby} = get_config_var($ref, "LIBRUBYARG");
+    }
     my $ruby_hdr_dir = get_config_var($ref, "rubyhdrdir");
     if ($ruby_hdr_dir ne 'nil') {
         my $arch = get_config_var($ref, "arch");

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -92,7 +92,7 @@ END
 #============================================================================
 $defs = join ' ', $WALL, qw(-UEXPOSE_PERL -DCREATE_RUBY -UCREATE_PERL),
     $debug ? "-DI_RB_DEBUG" : (),
-    (grep { defined } map { my $v = get_config_var($sel, $_); $v ne 'nil' ? "-DRUBY_VERSION_$_=$v" : undef } qw/MAJOR MINOR/);
+    (grep { defined } map { my $v = get_config_var($sel, $_); defined $v ? "-DRUBY_VERSION_$_=$v" : undef } qw/MAJOR MINOR/);
 
 my $lddlflags = $Config{lddlflags};
 $lddlflags =~ s/-L\S+//g;
@@ -183,17 +183,17 @@ sub interrogate {
             $ref->{libruby} = get_config_var($ref, "LIBRUBYARG");
     }
     my $ruby_hdr_dir = get_config_var($ref, "rubyhdrdir");
-    if ($ruby_hdr_dir ne 'nil') {
+    if (defined $ruby_hdr_dir) {
         my $arch = get_config_var($ref, "arch");
         # no "archhdrdir", so construct it by hand:
-        my $arch_hdr_dir = $arch ne 'nil' ? catdir($ruby_hdr_dir, $arch) : undef;
+        my $arch_hdr_dir = defined $arch ? catdir($ruby_hdr_dir, $arch) : undef;
         $ref->{incpath} = [ grep { defined } $ruby_hdr_dir, $arch_hdr_dir ];
     }
 
     # Ruby 1.6.4 supports archdir, which is what we need. But 1.6.3 (the
     # earliest version I have) doesn't, so we should build it ourselves.
     $ref->{libpath} = get_config_var($ref, "archdir");
-    if ($ref->{libpath} eq 'nil')
+    if (defined $ref->{libpath})
     {
         $ref->{libpath} =
         catdir(
@@ -231,7 +231,16 @@ sub get_config_var {
     my $ref = shift;
     my $key = shift;
     my $exe = $ref->{path};
-    my $val = `$exe -e "require 'rbconfig'; include RbConfig; puts CONFIG['$key']"`;
+    my $val = `\n\
+    $exe -e "require 'rbconfig'\n\
+             include RbConfig\n\
+             v = CONFIG['$key']\n\
+             if v == nil\n\
+                 exit 1\n\
+             end\n\
+             puts v"`;
+    return if $?;
+
     chomp $val;
     return $val;
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -200,7 +200,7 @@ sub get_config_var {
     my $ref = shift;
     my $key = shift;
     my $exe = $ref->{path};
-    my $val = `$exe -e "require 'rbconfig'; include Config; puts CONFIG['$key']"`;
+    my $val = `$exe -e "require 'rbconfig'; include RbConfig; puts CONFIG['$key']"`;
     chomp $val;
     return $val;
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use Data::Dumper;
 use Config;
+use Cwd qw(abs_path);
 use ExtUtils::MakeMaker;
 use Getopt::Long;
 use File::Spec::Functions;
@@ -22,25 +23,45 @@ usage() if $help;
 #============================================================================
 # What ruby are we going to run?
 #============================================================================
-my @rubies;
-for $p (split /$Config{path_sep}/, $ENV{PATH}) {
-    $p =~ s/^~/$ENV{HOME}/;
-    $p .= "/ruby";
-    push @rubies, { path => $p } if -f $p && -x $p;
+my $sel = $ENV{INLINE_RUBY_EXECUTABLE};
+unless (defined $sel && length $sel) {
+    my @rubies;
+    my %rubies;
+    my $sep = $^O eq 'MSWin32' ? ";" : ":";
+    for $p (split /$sep/, $ENV{PATH}) {
+        $p =~ s/^~/$ENV{HOME}/;
+        $p .= "/ruby";
+        next unless -f $p and -x $p;
+        next if $rubies{abs_path($p)}++; # filter symlinked duplicates
+        push @rubies, { path => $p };
+    }
+
+    # Keep them in PATH order.
+    # @rubies = sort { $a->{path} cmp $b->{path} } @rubies;
+
+    my $num = 1;
+    print "Found these ruby executables on your PATH:\n";
+    print $num++ . ". " . $_->{path} . "\n" for @rubies;
+
+    if (@rubies == 1 and not $sel) {
+        $sel = $rubies[0];
+        print "Using the only ruby executable I could find\n";
+        print 'Set the INLINE_RUBY_EXECUTABLE environment variable to'
+            . " the full path to your ruby executable to override this selection.\n";
+    }
+    unless ($sel) {
+        $sel = prompt("Use which?", '1');
+        if ($sel =~ /^\d+$/) {
+            die 'Invalid number. Please enter only numbers from 1 to ' . ($num - 1)
+                . " or the full path to your ruby executable.\n"
+                . 'Set the INLINE_RUBY_EXECUTABLE environment variable to'
+                . " the full path to your ruby executable to avoid this question.\n"
+                if $sel > ($num - 1);
+            $sel = $rubies[$sel - 1];
+        }
+    }
 }
-
-unless (@rubies) {
-    print "Could not find the ruby interpreter on your PATH. Stopping...\n";
-    exit 1;
-}
-
-my $num = 1;
-print "Found ${\(scalar @rubies)} ruby executables on your PATH.\n";
-print $num++ . ". " . $_->{path} . "\n" for @rubies;
-
-my $sel = prompt("Use which?", (scalar @rubies ? '1' : ()));
-$sel = $rubies[$sel-1] if $sel =~ /^\d+$/;
-$sel = { path => $sel } unless ref $sel eq 'HASH';
+$sel = { path => $sel } unless ref $sel eq 'HASH'; # in case the user entered a path
 
 print "Using $sel->{path}\n";
 

--- a/Ruby.pm
+++ b/Ruby.pm
@@ -28,7 +28,22 @@ sub import {
 
 sub dl_load_flags { 0x01 }
 Inline::Ruby->bootstrap($VERSION);
-_eval_support_code();
+
+use constant _GET_NAMESPACE => <<EOF;
+Proc.new {
+    ns = { 'classes' => {}, 'modules' => {}, 'f' => {} }
+    ObjectSpace.each_object(Class) do |x|
+        ns['classes'][x.name] = 1
+    end
+    ObjectSpace.each_object(Module) do |x|
+        ns['modules'][x.name] = 1
+    end
+    Kernel.methods.each do |x|
+        ns['f'][x] = 1
+    end
+    ns
+}.call
+EOF
 
 #==============================================================================
 # Register Ruby.pm as a valid Inline language
@@ -227,17 +242,15 @@ END
 sub build {
     my $o = shift;
     return if $o->{ILSM}{built};
-
+   
     # Filter the code
     $o->{ILSM}{code} = $o->filter(@{$o->{ILSM}{FILTERS}});
 
     # Get the namespace before & after evaluating the code:
     my (%pre, %post, %n);
-    rb_iter(undef, sub {my ($type, $name) = @_; $pre{$type}{$name}++})
-      ->inline_ruby_class_grokker;
+    %pre = rb_eval(_GET_NAMESPACE);
     rb_eval($o->{ILSM}{code});
-    rb_iter(undef, sub {my ($type, $name) = @_; $post{$type}{$name}++})
-      ->inline_ruby_class_grokker;
+    %post = rb_eval(_GET_NAMESPACE);
 
     # Select those things which sprang into existence after running the code:
     my @skip_clas = qw(PerlException PerlProc);
@@ -261,17 +274,47 @@ sub build {
 	}
     }
 
-    # Get more details about the classes and modules:
-    rb_iter(undef, sub { $n{$_[0]} = $_[1] })
-      ->inline_ruby_class_grokker(keys %{$post{classes}})
-	if (%{$post{classes} || {}});
-    rb_iter(undef, sub { $n{$_[0]} = $_[1] })
-      ->inline_ruby_class_grokker(keys %{$post{modules}})
-	if (%{$post{modules} || {}});
+    # Get more details about the classes and modules.
+    # FIXME! Is the quoting correct?
+    my $classes_arg = join ', ', map { quotemeta $_ } keys %{$post{classes}};
+    my %c = rb_eval(<<EOF);
+Proc.new {
+    ns = {}
+    classes = [$classes_arg]
+    classes.each do |k|
+        ns[k] = {}
+        begin
+            ns[k]['methods'] = eval "#{k}.methods"
+            ns[k]['imethods'] = eval "#{k}.instance_methods"
+        rescue Exception
+            p "Exception: " + \$!
+        end
+    end
+    ns
+}.call
+EOF
+
+    my $modules_arg = join ', ', map { quotemeta $_ } keys %{$post{modules}};
+    my %m = rb_eval(<<EOF);
+Proc.new {
+    ns = {}
+    classes = [$modules_arg]
+    classes.each do |k|
+        ns[k] = {}
+        begin
+            ns[k]['methods'] = eval "#{k}.methods"
+            ns[k]['imethods'] = eval "#{k}.instance_methods"
+        rescue Exception
+            p "Exception: " + \$!
+        end
+    end
+    ns
+}.call
+EOF
 
     # And the namespace is:
     my %namespace = (
-	classes		=> \%n,
+	classes		=> { %c, %m },
 	functions	=> [keys %{$post{functions} || {}}],
     );
 

--- a/Ruby.pm
+++ b/Ruby.pm
@@ -242,7 +242,7 @@ END
 sub build {
     my $o = shift;
     return if $o->{ILSM}{built};
-   
+
     # Filter the code
     $o->{ILSM}{code} = $o->filter(@{$o->{ILSM}{FILTERS}});
 

--- a/Ruby.pm
+++ b/Ruby.pm
@@ -28,7 +28,22 @@ sub import {
 
 sub dl_load_flags { 0x01 }
 Inline::Ruby->bootstrap($VERSION);
-_eval_support_code();
+
+use constant _GET_NAMESPACE => <<EOF;
+Proc.new {
+    ns = { 'classes' => {}, 'modules' => {}, 'f' => {} }
+    ObjectSpace.each_object(Class) do |x|
+        ns['classes'][x.name] = 1
+    end
+    ObjectSpace.each_object(Module) do |x|
+        ns['modules'][x.name] = 1
+    end
+    Kernel.methods.each do |x|
+        ns['f'][x] = 1
+    end
+    ns
+}.call
+EOF
 
 #==============================================================================
 # Register Ruby.pm as a valid Inline language
@@ -227,52 +242,79 @@ END
 sub build {
     my $o = shift;
     return if $o->{ILSM}{built};
-
+   
     # Filter the code
     $o->{ILSM}{code} = $o->filter(@{$o->{ILSM}{FILTERS}});
 
     # Get the namespace before & after evaluating the code:
-    my (%pre, %post, %n);
-    rb_iter(undef, sub {my ($type, $name) = @_; $pre{$type}{$name}++})
-      ->inline_ruby_class_grokker;
+    my $pre = rb_eval(_GET_NAMESPACE);
     rb_eval($o->{ILSM}{code});
-    rb_iter(undef, sub {my ($type, $name) = @_; $post{$type}{$name}++})
-      ->inline_ruby_class_grokker;
+    my $post = rb_eval(_GET_NAMESPACE);
 
     # Select those things which sprang into existence after running the code:
     my @skip_clas = qw(PerlException PerlProc);
-    my @skip_func = qw(inline_ruby_class_grokker);
-    delete @{ $post{classes} }{@skip_clas, keys(%{$pre{classes}})};
-    delete @{ $post{functions} }{@skip_func, keys(%{$pre{functions}})};
-    delete @{ $post{modules} }{
-        keys(%{$pre{modules}}), keys(%{$post{classes}})
+    my @skip_func = qw();
+    delete @{ $post->{classes} }{@skip_clas, keys(%{$pre->{classes}})};
+    delete @{ $post->{functions} }{@skip_func, keys(%{$pre->{functions}})};
+    delete @{ $post->{modules} }{
+        keys(%{$pre->{modules}}), keys(%{$post->{classes}})
     };
 
     # Filter the results according to the {bindto} and {REGEXP} selections:
     for my $type (qw(classes modules functions)) {
 	if ($o->{ILSM}{bindto}) {
-	    delete $post{$type}
+	    delete $post->{$type}
 	      unless grep { $_ eq $type } @{$o->{ILSM}{bindto}};
 	}
 	if ($o->{ILSM}{regexp}) {
-	    for my $k (keys %{$post{$type}}) {
-		delete $post{$type}{$k} unless $k =~ $o->{ILSM}{regexp};
+	    for my $k (keys %{$post->{$type}}) {
+		delete $post->{$type}{$k} unless $k =~ $o->{ILSM}{regexp};
 	    }
 	}
     }
 
-    # Get more details about the classes and modules:
-    rb_iter(undef, sub { $n{$_[0]} = $_[1] })
-      ->inline_ruby_class_grokker(keys %{$post{classes}})
-	if (%{$post{classes} || {}});
-    rb_iter(undef, sub { $n{$_[0]} = $_[1] })
-      ->inline_ruby_class_grokker(keys %{$post{modules}})
-	if (%{$post{modules} || {}});
+    # Get more details about the classes and modules.
+    # FIXME! Is the quoting correct?
+    my $classes_arg = join ', ', map { quotemeta $_ } keys %{$post->{classes}};
+    my %c = rb_eval(<<EOF);
+Proc.new {
+    ns = {}
+    classes = [$classes_arg]
+    classes.each do |k|
+        ns[k] = {}
+        begin
+            ns[k]['methods'] = eval "#{k}.methods"
+            ns[k]['imethods'] = eval "#{k}.instance_methods"
+        rescue Exception
+            p "Exception: " + \$!
+        end
+    end
+    ns
+}.call
+EOF
+
+    my $modules_arg = join ', ', map { quotemeta $_ } keys %{$post->{modules}};
+    my %m = rb_eval(<<EOF);
+Proc.new {
+    ns = {}
+    classes = [$modules_arg]
+    classes.each do |k|
+        ns[k] = {}
+        begin
+            ns[k]['methods'] = eval "#{k}.methods"
+            ns[k]['imethods'] = eval "#{k}.instance_methods"
+        rescue Exception
+            p "Exception: " + \$!
+        end
+    end
+    ns
+}.call
+EOF
 
     # And the namespace is:
     my %namespace = (
-	classes		=> \%n,
-	functions	=> [keys %{$post{functions} || {}}],
+	classes		=> { %c, %m },
+	functions	=> [keys %{$post->{functions} || {}}],
     );
 
     if ((! @{$namespace{functions}})

--- a/Ruby.pm
+++ b/Ruby.pm
@@ -31,15 +31,15 @@ Inline::Ruby->bootstrap($VERSION);
 
 use constant _GET_NAMESPACE => <<EOF;
 Proc.new {
-    ns = { 'classes' => {}, 'modules' => {}, 'f' => {} }
+    ns = { 'classes' => {}, 'modules' => {}, 'functions' => {} }
     ObjectSpace.each_object(Class) do |x|
         ns['classes'][x.name] = 1
     end
     ObjectSpace.each_object(Module) do |x|
         ns['modules'][x.name] = 1
     end
-    Kernel.methods.each do |x|
-        ns['f'][x] = 1
+    Object.private_instance_methods.each do |x|
+        ns['functions'][x] = 1
     end
     ns
 }.call
@@ -276,7 +276,7 @@ sub build {
     # Get more details about the classes and modules.
     # FIXME! Is the quoting correct?
     my $classes_arg = join ', ', map { quotemeta $_ } keys %{$post->{classes}};
-    my %c = rb_eval(<<EOF);
+    my $c = rb_eval(<<EOF);
 Proc.new {
     ns = {}
     classes = [$classes_arg]
@@ -294,7 +294,7 @@ Proc.new {
 EOF
 
     my $modules_arg = join ', ', map { quotemeta $_ } keys %{$post->{modules}};
-    my %m = rb_eval(<<EOF);
+    my $m = rb_eval(<<EOF);
 Proc.new {
     ns = {}
     classes = [$modules_arg]
@@ -313,7 +313,7 @@ EOF
 
     # And the namespace is:
     my %namespace = (
-	classes		=> { %c, %m },
+	classes		=> { %$c, %$m },
 	functions	=> [keys %{$post->{functions} || {}}],
     );
 

--- a/Ruby.xs
+++ b/Ruby.xs
@@ -129,7 +129,7 @@ my_iter_it(fake)
 {
     VALUE obj, method, args;
 
-    Printf(("Note: in my_iter_it(%p)\n", fake));
+    Printf(("Note: in my_iter_it(%p)\n", (void *) fake));
     Printf(("Type: TYPE(fake) = %i\n", TYPE(fake)));
     obj		= rb_ary_entry(fake, 0);
     method	= rb_ary_entry(fake, 1);
@@ -316,7 +316,7 @@ my_error_wrapper(arg)
 	VALUE it_args;
 	it_args = rb_ary_new3(3, obj, rb_str_new2(method), argv);
 	Printf(("Note: calling rb_interate(%p, %p, %p, %p)\n",
-	       my_iter_it, it_args, my_iter_bl, iter));
+	       my_iter_it, (void *) it_args, my_iter_bl, iter));
 	retv = rb_iterate(&my_iter_it, it_args, &my_iter_bl, (VALUE)iter);
     }
     else {
@@ -356,7 +356,7 @@ call_ruby_method(obj, method, iter, argv)
     VALUE	wrap_argv;
     VALUE	rb_retval;
 
-    Printf(("call_ruby_method(%p, '%s', %p)\n", obj, method, iter));
+    Printf(("call_ruby_method(%p, '%s', %p)\n", (void *) obj, method, iter));
 
     /* If obj is a string, it is the name the class upon which to call the
      * class method. */
@@ -494,7 +494,7 @@ my_rb_call_class_method(KLASS, mname, ...)
 	VALUE	argv;
 	SV*	pl_retval;
     PPCODE:
-	Printf(("rb_call_class_method('%s', '%s', %p, ...)\n",KLASS,mname));
+	Printf(("rb_call_class_method('%s', '%s', ...)\n",KLASS,mname));
 
 	INIT_RUBY_ARGV(argv);
 	klass = rb_str_new2(KLASS);
@@ -523,13 +523,13 @@ my_rb_call_instance_method(_inst, mname, ...)
 	SV*	pl_retval;
 	SV*	iter;
     PPCODE:
-	Printf(("rb_call_instance_method(%p, '%s', %p, ...)\n",
+	Printf(("rb_call_instance_method(%p, '%s', ...)\n",
 		_inst, mname));
 
 	if (isa_InlineRubyWrapper(_inst)) {
 	    inst = UNWRAP_RUBY_OBJ(_inst);
 	    iter = INLINE_MAGIC(_inst)->iter;
-	    Printf(("inst (%p) successfully passed the PVMG test\n", inst));
+	    Printf(("inst (%p) successfully passed the PVMG test\n", (void *) inst));
 	}
 	else {
 	    croak("Object is not a wrapped Inline::Ruby::Object object");

--- a/rb2pl.c
+++ b/rb2pl.c
@@ -304,8 +304,8 @@ rb2pl(VALUE obj) {
 			/* Perl can only use strings as hash keys.
 			 * Use the stringified key, and emit a warning if
 			 * warnings are turned on. */
-			key = rb_convert_type(key, T_STRING, "String", "to_str");
-			warn("Warning: stringifying a hash-key may lose info!");
+			key = rb_convert_type(key, T_STRING, "String", "to_s");
+			/* warn("Warning: stringifying a hash-key may lose info!"); */
 		    }
 		    key_c = RSTRING_PTR(key);
 		    klen = RSTRING_LEN(key);

--- a/rb2pl.c
+++ b/rb2pl.c
@@ -4,7 +4,7 @@
  ****************************************************************************/
 
 #include "rb2pl.h"
-#if RUBY_VERSION_MAJOR > 1 || (RUBY_VERSION_MAJOR == 1 && RUBY_VERSION_MINOR > 9)
+#if RUBY_VERSION_MAJOR > 1 || (RUBY_VERSION_MAJOR == 1 && RUBY_VERSION_MINOR >= 9)
 #include "ruby/st.h"
 #else
 #include "st.h"		/* ST_CONTINUE */

--- a/rb2pl.c
+++ b/rb2pl.c
@@ -4,7 +4,7 @@
  ****************************************************************************/
 
 #include "rb2pl.h"
-#if RUBY_VERSION_MAJOR == 1 && RUBY_VERSION_MINOR == 9
+#if RUBY_VERSION_MAJOR > 1 || (RUBY_VERSION_MAJOR == 1 && RUBY_VERSION_MINOR > 9)
 #include "ruby/st.h"
 #else
 #include "st.h"		/* ST_CONTINUE */

--- a/rb2pl.h
+++ b/rb2pl.h
@@ -32,7 +32,7 @@
  * - https://www.ruby-forum.com/topic/215406
  * */
 #ifndef STR2CSTR
-#define STR2CSTR(x) StringValuePtr(x)
+#define STR2CSTR(x) ({VALUE _v = (VALUE) x; StringValuePtr(_v); })
 #endif
 /*
  * See:

--- a/t/05rb_exc.t
+++ b/t/05rb_exc.t
@@ -49,5 +49,5 @@ e(  "1/0",
 
 # parse error
 e(  "1/",
-    [qr/(?:compile error)|(?:syntax error, unexpected \$end)/, 'SyntaxError'],
+    [qr/(?:compile error)|(?:syntax error, unexpected (?:\$end|end-of-input))/, 'SyntaxError'],
 );


### PR DESCRIPTION
The module compiles and links and passes all tests on these platforms:

- Gentoo Linux, ruby 2.1.9
- Gentoo Linux, ruby 2.2.6
- MacPorts, ruby 1.8.7
- MacPorts, ruby 1.9.3
- MacPorts, ruby 2.0.0
- MacPorts, ruby 2.4.1
- Mac OS 10.12.6 (Sierra), ruby 2.0.0

Changes:

- fixed compiler and linker flags for recent ruby versions
- fixed linker flags for MacPorts
- rewritten namespace inspection (did not work for ruby 1.9 or better)
- fixed various compiler warnings

TODO:

The documentation should be updated.