### PR TITLE
fix for https://rt.cpan.org/Ticket/Display.html?id=128484

### DIFF
--- a/Ruby.pm
+++ b/Ruby.pm
@@ -228,7 +228,7 @@ sub build {
     delete @{ $post->{classes} }{@skip_clas, keys(%{$pre->{classes}})};
     delete @{ $post->{functions} }{@skip_func, keys(%{$pre->{functions}})};
     delete @{ $post->{modules} }{
-        keys(%{$pre->{modules}}), keys(%{$post->{classes}})
+        keys(%{$pre->{modules}}), keys(%{$post->{classes}}), grep /:[a-z]/, keys(%{$post->{modules}})
     };
 
     # Filter the results according to the {bindto} and {REGEXP} selections:

--- a/t/01basic.t
+++ b/t/01basic.t
@@ -76,3 +76,15 @@ end
 def some_iter(a)
   yield a
 end
+
+require 'stringio'
+
+# Inherit from StringIO to test fix for https://rt.cpan.org/Ticket/Display.html?id=128484
+class Test128484 < StringIO
+  def a_method()
+      # The code from the script attached to the bug report didn't
+      # include this method and didn't reproduce the error when I put
+      # it here. I'm not sure why, but adding this method caused the
+      # bug to be provoked in this test script.
+  end
+end


### PR DESCRIPTION
The bug is due to the fact that two internal modules, IO::generic_readable and IO::generic_writable, are included by StringIO but because their names begin with lower case letters they are not accessible by name. (I'm not sure why NoMethodError is being raised instead of NameError, but it is.)