### PR TITLE
Get exception type

### DIFF
--- a/Ruby.xs
+++ b/Ruby.xs
@@ -656,8 +656,7 @@ type(obj)
 	RETRIEVE_CACHE(method);
 	{
 	    VALUE rb_exception = (VALUE)SvIV(*hv_fetch(wrapper, "_rb_exc", 7, FALSE));
-	    VALUE klass = rb_funcall(rb_exception, rb_intern("class"), 0);
-	    RETVAL = rb2pl(rb_funcall(klass, rb_intern("name"), 0));
+        RETVAL = rb2pl(rb_inspect(rb_exception));
 	    STORE_CACHE(method, newSVsv(RETVAL));
 	}
     OUTPUT:

--- a/t/02iter.t
+++ b/t/02iter.t
@@ -40,7 +40,7 @@ eval {
 };
 my $Err = $@;
 # TEST
-is ($Err->type, 'LocalJumpError', "Error type");
+is ($Err->type, '#<LocalJumpError: no block given (yield)>', "Error type");
 # TEST
 like (
     $Err->message,

--- a/t/05rb_exc.t
+++ b/t/05rb_exc.t
@@ -13,7 +13,7 @@ sub e {
     return unless $@;
     my $x = $@;
 
-    my $inspect = sprintf("#<%s: %s>", $x->type, $x->message);
+    my $inspect = $x->type;
 
     # TEST*$n
     # Methods:
@@ -24,7 +24,7 @@ sub e {
     # print Dumper $x->message;
 
     # TEST*$n
-    is ($x->type, $exc->[1], 'Type is right');
+    is ($inspect, sprintf("#<%s: %s>", $exc->[1], $x->message), 'Type is right');
     # print Dumper $x->type;
 
     # TEST*$n

--- a/t/06pl_exc.t
+++ b/t/06pl_exc.t
@@ -36,7 +36,8 @@ sub test_exception {
 
     # TEST*$n
     my $str = (split /\n/, "$x")[0];
-    is ($str, $x->inspect, "Stringification for $n");
+    my $expected = (split /\n/, $x->inspect)[0];
+    is ($str, $expected, "Stringification for $n");
 
     # Not tested:
     # print Dumper $x->inspect;

--- a/t/06pl_exc.t
+++ b/t/06pl_exc.t
@@ -27,11 +27,16 @@ sub test_exception {
     # print Dumper $x->message;
 
     # TEST*$n
-    is ($x->type, $exc[$n][1], "Type for $n");
+    my $type = $x->type;
+    $type =~ s/\\n/\n/g;
+    $type =~ s/:"/: /;
+    $type =~ s/">/>/;
+    is ($type, sprintf('#<%s: %s>', $exc[$n][1], $x->message), "Type for $n");
     # print Dumper $x->type;
 
     # TEST*$n
-    is ("$x", $x->inspect . "\n", "Stringification for $n");
+    my $str = (split /\n/, "$x")[0];
+    is ($str, $x->inspect, "Stringification for $n");
 
     # Not tested:
     # print Dumper $x->inspect;


### PR DESCRIPTION
Fixes issue #10 by using `rb_inspect()` to find the exception type.